### PR TITLE
feat(#178): 🔐 Define global backoffice.read_only permission and role mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Set these variables in Render dashboard (or through Blueprint secrets), never in
 
 - `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_ID`
 - `SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_SECRET`
-- `APP_AUTH_ALLOWED_EMAILS`
-- `APP_AUTH_READ_ONLY_EMAILS` (optional; **planned — not yet active**, rolling out via the backoffice read-only model in #178–#181. Once live: comma-separated emails granted **read-only** backoffice access — view every module's lists/detail, no create/edit/delete/archive. Admins in `APP_AUTH_ALLOWED_EMAILS` keep full access. See [Backoffice read-only permissions](docs/backoffice-read-only-permissions.md))
+- `APP_AUTH_ADMIN_EMAILS`
+- `APP_AUTH_READ_ONLY_EMAILS` (optional; comma-separated emails for the **read-only** backoffice tier. **Recognized and resolvable as of #178 but not yet enforced** — write-blocking (#179/#181) and UI hiding (#180) are still pending. Once live: read-only users view every module's lists/detail with no create/edit/delete/archive. Admins in `APP_AUTH_ADMIN_EMAILS` keep full access. See [Backoffice read-only permissions](docs/backoffice-read-only-permissions.md))
 - `APP_CORS_ALLOWED_ORIGINS`
 - `APP_AUTH_SUCCESS_REDIRECT_URL`
 - `POSTGRES_HOST`

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 
 group = "me.elgregoss"
-version = "0.0.46-SNAPSHOT"
+version = "0.0.47-SNAPSHOT"
 
 java {
     toolchain {

--- a/backend/src/integrationTest/resources/application-test.yml
+++ b/backend/src/integrationTest/resources/application-test.yml
@@ -14,7 +14,7 @@ spring:
 
 app:
   auth:
-    allowed-emails:
+    admin-emails:
       - gregory@example.com
     success-redirect-url: http://localhost:5173
   deezer:

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/api/auth/AuthEndpoint.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/api/auth/AuthEndpoint.kt
@@ -31,7 +31,12 @@ class AuthEndpoint(
             AuthStatusResponse(
                 isAuthenticated = oauth2User != null,
                 email = email,
-                isAuthorized = authProperties.isAllowed(email)
+                // Backoffice entry is admin-only for now, matching the still-admin-only API gate
+                // (SecurityConfig). This broadens to "has any backoffice role" — and starts reporting
+                // the resolved capabilities — once read-only reads are enforced (#179) and the UI
+                // consumes them (#180); flipping it earlier would admit read-only users into a UI whose
+                // API calls all return 403.
+                isAuthorized = authProperties.isAdmin(email)
             )
         )
     }

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/AuthConfigurationValidator.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/AuthConfigurationValidator.kt
@@ -5,14 +5,14 @@ import org.springframework.stereotype.Component
 
 @Component
 class AuthConfigurationValidator(
-    private val environment: Environment,
-    private val authProperties: AuthProperties,
+    environment: Environment,
+    authProperties: AuthProperties,
 ) {
 
     init {
         if (environment.activeProfiles.contains("prod")) {
-            check(authProperties.normalizedAllowedEmails().isNotEmpty()) {
-                "app.auth.allowed-emails must not be empty in prod profile"
+            check(authProperties.normalizedAdminEmails().isNotEmpty()) {
+                "app.auth.admin-emails must not be empty in prod profile"
             }
 
             val redirectUrl = authProperties.successRedirectUrl.trim()

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/AuthProperties.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/AuthProperties.kt
@@ -4,17 +4,21 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("app.auth")
 data class AuthProperties(
-    val allowedEmails: List<String> = emptyList(),
+    val adminEmails: List<String> = emptyList(),
+    val readOnlyEmails: List<String> = emptyList(),
     val successRedirectUrl: String = "http://localhost:5173",
 ) {
-    fun normalizedAllowedEmails(): Set<String> = allowedEmails
-        .map { it.trim().lowercase() }
-        .filter { it.isNotBlank() }
-        .toSet()
+    // Config is immutable at runtime, so normalize once instead of on every /api/** request.
+    private val adminAllowlist: EmailAllowlist = EmailAllowlist(adminEmails)
 
-    fun isAllowed(email: String?): Boolean = email
-        ?.trim()
-        ?.lowercase()
-        ?.let { it in normalizedAllowedEmails() }
-        ?: false
+    private val readOnlyAllowlist: EmailAllowlist = EmailAllowlist(readOnlyEmails)
+
+    fun adminAllowlist(): EmailAllowlist = adminAllowlist
+
+    fun readOnlyAllowlist(): EmailAllowlist = readOnlyAllowlist
+
+    // Thin delegates kept for the admin-gate call sites (SecurityConfig, AuthEndpoint, validator).
+    fun isAdmin(email: String?): Boolean = email in adminAllowlist
+
+    fun normalizedAdminEmails(): Set<String> = adminAllowlist.values
 }

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeAuthorization.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeAuthorization.kt
@@ -1,0 +1,40 @@
+package me.elgregos.theweddingplan.infrastructure.config
+
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves a caller's backoffice [BackofficeRole] and granted [BackofficeCapability] set from the
+ * configured email allowlists (`app.auth.admin-emails` and `app.auth.read-only-emails`).
+ *
+ * Precedence is deterministic and **most-privileged-wins**: an email present in both allowlists resolves
+ * to [BackofficeRole.ADMIN], so the read-only tier can never downgrade an admin. This is the single
+ * authorization primitive the backoffice enforcement (#179 / #181) and UI guard (#180) build on.
+ */
+@Component
+class BackofficeAuthorization(
+    authProperties: AuthProperties,
+) {
+
+    /**
+     * Role → allowlist, ordered by precedence (most-privileged first). Resolution returns the first
+     * matching role, so an email in several allowlists resolves to the most privileged one. Adding a
+     * role is a single entry here plus its allowlist on [AuthProperties].
+     */
+    private val allowlistsByRole: List<Pair<BackofficeRole, EmailAllowlist>> = listOf(
+        BackofficeRole.ADMIN to authProperties.adminAllowlist(),
+        BackofficeRole.READ_ONLY to authProperties.readOnlyAllowlist(),
+    )
+
+    fun roleOf(email: String?): BackofficeRole? =
+        allowlistsByRole.firstOrNull { (_, allowlist) -> email in allowlist }?.first
+
+    fun capabilitiesOf(email: String?): Set<BackofficeCapability> =
+        roleOf(email)?.capabilities ?: emptySet()
+
+    fun hasCapability(email: String?, capability: BackofficeCapability): Boolean =
+        capability in capabilitiesOf(email)
+}
+
+
+
+

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeCapability.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeCapability.kt
@@ -1,0 +1,22 @@
+package me.elgregos.theweddingplan.infrastructure.config
+
+/**
+ * Authoritative backoffice authorization capabilities — the **positive** actions a caller may perform,
+ * shared by every module (no per-module permissions).
+ *
+ * - [READ] (`backoffice.read`) — view backoffice resources (safe HTTP methods).
+ * - [WRITE] (`backoffice.write`) — create / update / delete backoffice resources (mutating methods).
+ *
+ * The read-only role grants [READ] only; admins grant both, so an admin always holds a superset of a
+ * read-only user. Enforcement (#179 / #181) requires [WRITE] for mutations, and the UI guard (#180)
+ * hides write affordances when [WRITE] is absent.
+ *
+ * The [id] is the stable string form used when a capability is surfaced outside the JVM (e.g. in the
+ * `/auth/me` payload) and must not change without coordinating consumers.
+ */
+enum class BackofficeCapability(val id: String) {
+    READ("backoffice.read"),
+    WRITE("backoffice.write"),
+}
+
+

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeRole.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeRole.kt
@@ -1,0 +1,20 @@
+package me.elgregos.theweddingplan.infrastructure.config
+
+/**
+ * Backoffice authorization roles with the capabilities each one grants.
+ *
+ * - [ADMIN] — full access: grants both [BackofficeCapability.READ] and [BackofficeCapability.WRITE].
+ * - [READ_ONLY] — read (safe) access only: grants [BackofficeCapability.READ].
+ *
+ * Capabilities are **positive grants**, so an admin always holds a superset of a read-only user (never
+ * an empty set). Declaration order is **precedence, most-privileged first** (see [BackofficeAuthorization]).
+ * Adding a future role means adding an entry here with the capabilities it grants — no resolver `when`
+ * branches to touch.
+ */
+enum class BackofficeRole(val capabilities: Set<BackofficeCapability>) {
+    ADMIN(setOf(BackofficeCapability.READ, BackofficeCapability.WRITE)),
+    READ_ONLY(setOf(BackofficeCapability.READ)),
+}
+
+
+

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/EmailAllowlist.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/EmailAllowlist.kt
@@ -1,0 +1,19 @@
+package me.elgregos.theweddingplan.infrastructure.config
+
+/**
+ * A case-insensitive, whitespace-trimming set of email addresses.
+ *
+ * Encapsulates the normalization and membership rules **once** so every tier (admin, read-only, and any
+ * future role) behaves identically — adding a new allowlist never re-implements this logic.
+ */
+class EmailAllowlist(rawEmails: List<String>) {
+
+    val values: Set<String> = rawEmails
+        .map { it.trim().lowercase() }
+        .filter { it.isNotBlank() }
+        .toSet()
+
+    operator fun contains(email: String?): Boolean =
+        email?.let { it.trim().lowercase() in values } ?: false
+}
+

--- a/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/me/elgregos/theweddingplan/infrastructure/config/SecurityConfig.kt
@@ -116,7 +116,7 @@ class SecurityConfig(
                         val email = (authentication.get().principal as? OAuth2User)
                             ?.getAttribute<String>("email")
 
-                        AuthorizationDecision(authProperties.isAllowed(email))
+                        AuthorizationDecision(authProperties.isAdmin(email))
                     }
                     .requestMatchers(
                         "/",

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -54,7 +54,8 @@ spring:
 
 app:
   auth:
-    allowed-emails: ${APP_AUTH_ALLOWED_EMAILS:}
+    admin-emails: ${APP_AUTH_ADMIN_EMAILS:}
+    read-only-emails: ${APP_AUTH_READ_ONLY_EMAILS:}
     success-redirect-url: ${APP_AUTH_SUCCESS_REDIRECT_URL:}
     rate-limit:
       enabled: ${APP_AUTH_RATE_LIMIT_ENABLED:true}

--- a/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/AuthConfigurationValidatorTest.kt
+++ b/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/AuthConfigurationValidatorTest.kt
@@ -17,7 +17,7 @@ class AuthConfigurationValidatorTest {
         val validator = AuthConfigurationValidator(
             environment = environment,
             authProperties = AuthProperties(
-                allowedEmails = emptyList(),
+                adminEmails = emptyList(),
                 successRedirectUrl = "http://localhost:5173",
             ),
         )
@@ -26,20 +26,20 @@ class AuthConfigurationValidatorTest {
     }
 
     @Test
-    fun `should fail in prod when allowed emails are empty`() {
+    fun `should fail in prod when admin emails are empty`() {
         val environment = StandardEnvironment().apply { setActiveProfiles("prod") }
 
         assertFailure {
             AuthConfigurationValidator(
                 environment = environment,
                 authProperties = AuthProperties(
-                    allowedEmails = emptyList(),
+                    adminEmails = emptyList(),
                     successRedirectUrl = "https://wedding.example.com",
                 ),
             )
         }
             .isInstanceOf(IllegalStateException::class)
-            .hasMessage("app.auth.allowed-emails must not be empty in prod profile")
+            .hasMessage("app.auth.admin-emails must not be empty in prod profile")
     }
 
     @Test
@@ -50,7 +50,7 @@ class AuthConfigurationValidatorTest {
             AuthConfigurationValidator(
                 environment = environment,
                 authProperties = AuthProperties(
-                    allowedEmails = listOf("gregory@example.com"),
+                    adminEmails = listOf("gregory@example.com"),
                     successRedirectUrl = "http://localhost:5173",
                 ),
             )
@@ -66,7 +66,7 @@ class AuthConfigurationValidatorTest {
         val validator = AuthConfigurationValidator(
             environment = environment,
             authProperties = AuthProperties(
-                allowedEmails = listOf("gregory@example.com"),
+                adminEmails = listOf("gregory@example.com"),
                 successRedirectUrl = "https://wedding.example.com",
             ),
         )

--- a/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeAuthorizationTest.kt
+++ b/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/BackofficeAuthorizationTest.kt
@@ -1,0 +1,102 @@
+package me.elgregos.theweddingplan.infrastructure.config
+
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class BackofficeAuthorizationTest {
+
+    private lateinit var backofficeAuthorization: BackofficeAuthorization
+
+    @BeforeTest
+    fun setUp() {
+        backofficeAuthorization = BackofficeAuthorization(
+            AuthProperties(
+                adminEmails = listOf("Admin@Example.com"),
+                readOnlyEmails = listOf("  Viewer@Example.com  "),
+            )
+        )
+    }
+
+    @Test
+    fun `should resolve admin role for an allowed email`() {
+        assertThat(backofficeAuthorization.roleOf("admin@example.com")).isEqualTo(BackofficeRole.ADMIN)
+    }
+
+    @Test
+    fun `should resolve read-only role for a read-only email regardless of case and whitespace`() {
+        assertThat(backofficeAuthorization.roleOf("viewer@example.com")).isEqualTo(BackofficeRole.READ_ONLY)
+    }
+
+    @Test
+    fun `should resolve no role for an unknown email`() {
+        assertThat(backofficeAuthorization.roleOf("stranger@example.com")).isNull()
+    }
+
+    @Test
+    fun `should resolve no role for a null email`() {
+        assertThat(backofficeAuthorization.roleOf(null)).isNull()
+    }
+
+    @Test
+    fun `should prefer admin when an email is in both allowlists`() {
+        val authorization = BackofficeAuthorization(
+            AuthProperties(
+                adminEmails = listOf("both@example.com"),
+                readOnlyEmails = listOf("both@example.com"),
+            )
+        )
+
+        assertThat(authorization.roleOf("both@example.com")).isEqualTo(BackofficeRole.ADMIN)
+    }
+
+    @Test
+    fun `should grant read and write capabilities to an admin`() {
+        assertThat(backofficeAuthorization.capabilitiesOf("admin@example.com"))
+            .containsOnly(BackofficeCapability.READ, BackofficeCapability.WRITE)
+    }
+
+    @Test
+    fun `should grant only the read capability to a read-only email`() {
+        assertThat(backofficeAuthorization.capabilitiesOf("viewer@example.com"))
+            .containsOnly(BackofficeCapability.READ)
+    }
+
+    @Test
+    fun `should not grant any capability to an unknown email`() {
+        assertThat(backofficeAuthorization.capabilitiesOf("stranger@example.com")).isEmpty()
+    }
+
+    @Test
+    fun `should confirm a read-only email may read but not write`() {
+        assertThat(backofficeAuthorization.hasCapability("viewer@example.com", BackofficeCapability.READ)).isTrue()
+    }
+
+    @Test
+    fun `should confirm a read-only email lacks the write capability`() {
+        assertThat(backofficeAuthorization.hasCapability("viewer@example.com", BackofficeCapability.WRITE)).isFalse()
+    }
+
+    @Test
+    fun `should confirm an admin may write`() {
+        assertThat(backofficeAuthorization.hasCapability("admin@example.com", BackofficeCapability.WRITE)).isTrue()
+    }
+
+    @Test
+    fun `should expose the authoritative capability ids`() {
+        assertThat(BackofficeCapability.READ.id).isEqualTo("backoffice.read")
+        assertThat(BackofficeCapability.WRITE.id).isEqualTo("backoffice.write")
+    }
+}
+
+
+
+
+
+

--- a/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/EmailAllowlistTest.kt
+++ b/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/EmailAllowlistTest.kt
@@ -1,0 +1,44 @@
+package me.elgregos.theweddingplan.infrastructure.config
+
+import assertk.assertThat
+import assertk.assertions.containsOnly
+import assertk.assertions.isEmpty
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class EmailAllowlistTest {
+
+    private val allowlist = EmailAllowlist(listOf("  Admin@Example.com  ", "viewer@example.com", "   "))
+
+    @Test
+    fun `should normalize entries by trimming, lowercasing, and dropping blanks`() {
+        assertThat(allowlist.values).containsOnly("admin@example.com", "viewer@example.com")
+    }
+
+    @Test
+    fun `should match an email regardless of case and surrounding whitespace`() {
+        assertThat("  ADMIN@example.COM  " in allowlist).isTrue()
+    }
+
+    @Test
+    fun `should not match an unknown email`() {
+        assertThat("stranger@example.com" in allowlist).isFalse()
+    }
+
+    @Test
+    fun `should not match a null email`() {
+        assertThat(null in allowlist).isFalse()
+    }
+
+    @Test
+    fun `should not match a blank email`() {
+        assertThat("   " in allowlist).isFalse()
+    }
+
+    @Test
+    fun `should expose no values for an empty allowlist`() {
+        assertThat(EmailAllowlist(emptyList()).values).isEmpty()
+    }
+}
+

--- a/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/SecurityConfigTest.kt
+++ b/backend/src/test/kotlin/me/elgregos/theweddingplan/infrastructure/config/SecurityConfigTest.kt
@@ -46,7 +46,7 @@ class SecurityConfigTest {
     ) = SecurityConfig(
         corsProperties = CorsProperties(allowedOrigins = allowedOrigins),
         authProperties = AuthProperties(
-            allowedEmails = listOf("gregory@example.com"),
+            adminEmails = listOf("gregory@example.com"),
             successRedirectUrl = successRedirectUrl,
         ),
     )

--- a/docs/backoffice-read-only-permissions.md
+++ b/docs/backoffice-read-only-permissions.md
@@ -12,28 +12,33 @@ a contributor can apply the pattern to any module **without tribal knowledge**.
 
 ## Status
 
-> ⚠️ **This document describes the _target_ model, not current behavior.**
+> ⚠️ **This document describes the _target_ model; parts are not yet live.**
 >
-> **Today (allowlist-only):** the backend has a single allowlist, `app.auth.allowed-emails`
-> (`APP_AUTH_ALLOWED_EMAILS`), which grants **full** backoffice access; there is no read-only tier.
-> `GET /auth/me` returns only `isAuthenticated`, `email`, and `isAuthorized` — no role or capability
-> field.
+> **Available now (as of #178):** the backend has two allowlists — `app.auth.admin-emails`
+> (`APP_AUTH_ADMIN_EMAILS`, admin) and `app.auth.read-only-emails` (`APP_AUTH_READ_ONLY_EMAILS`,
+> read-only) — and the auth layer can resolve a caller's `BackofficeRole` and granted capabilities
+> (`backoffice.read` / `backoffice.write` via `BackofficeAuthorization`), with admin-wins precedence.
 >
-> **Target (this document):** the `backoffice.read_only` capability, the `app.auth.read-only-emails`
-> (`APP_AUTH_READ_ONLY_EMAILS`) allowlist, the global verb-based enforcement, and the `/auth/me`
-> capability field are introduced across sub-issues **#178–#183**. Until those ship, the configuration
-> and behavior below are the **agreed design**, not live behavior — read "is/are" as "will be".
+> **Not yet enforced:** the resolved capability does **not** yet change behavior. `/api/**` still gates
+> on admin-only access, so read-only users are currently still denied writes *and reads* until the
+> global enforcement lands (#179 / #181); the UI does not yet hide write actions (#180); and
+> `GET /auth/me` still returns only `isAuthenticated`, `email`, and `isAuthorized` (no capability field
+> until #180 needs it). Until those ship, the enforcement/UI sections below are the **agreed design**,
+> not live behavior — read "is/are" as "will be".
 
-## Roles & the `backoffice.read_only` capability
+## Roles & backoffice capabilities
 
-_Target model — delivered by #178 (capability & role mapping). Not active yet; see [Status](#status)._
+_Capabilities, role mapping, and precedence are **implemented** as of #178
+(`BackofficeAuthorization` / `BackofficeCapability` / `BackofficeRole`). Enforcement (#179 / #181) and
+the UI guard (#180) are still pending; see [Status](#status)._
 
-Backoffice access is granted through Google OAuth2 login combined with email allowlists. The model has
-a single, authoritative read-only capability — **`backoffice.read_only`** — shared by every module (#178):
+Backoffice access is granted through Google OAuth2 login combined with email allowlists. Access is
+expressed as two **positive** capabilities shared by every module — `backoffice.read` and
+`backoffice.write` — and each role grants a subset (#178):
 
-- **Admin** — full read **and** write across all backoffice modules. Assigned via
-  `app.auth.allowed-emails` (`APP_AUTH_ALLOWED_EMAILS`).
-- **Read-only** — holds the `backoffice.read_only` capability: may view every backoffice list/detail but
+- **Admin** — grants **both** `backoffice.read` and `backoffice.write` (full access). Assigned via
+  `app.auth.admin-emails` (`APP_AUTH_ADMIN_EMAILS`).
+- **Read-only** — grants only `backoffice.read`: may view every backoffice list/detail but
   cannot perform any mutation. Assigned via `app.auth.read-only-emails` (`APP_AUTH_READ_ONLY_EMAILS`).
 
 A signed-in Google user whose email is in **neither** list is *unauthorized* and receives `403` on any
@@ -98,7 +103,7 @@ This path is **not** part of the Admin / read-only model:
   invitation's view, never the list.
 - Attendee **mutations** (RSVP, song choices under `/api/guest-access/secured/**`) require a magic-link
   guest session, described in [Guest magic-link authentication](guest-magic-link-security.md).
-- `APP_AUTH_READ_ONLY_EMAILS` and `APP_AUTH_ALLOWED_EMAILS` have **no effect** on this path.
+- `APP_AUTH_READ_ONLY_EMAILS` and `APP_AUTH_ADMIN_EMAILS` have **no effect** on this path.
 
 In short: backoffice access is gated by staff **roles**; attendee access is gated by **token
 possession**. The two are independent.
@@ -119,13 +124,13 @@ Assignment is configuration-only; no database change or code redeploy is require
    Locally, set the same value via `app.auth.read-only-emails` in your environment or an untracked
    override.
 
-2. Ensure the email is **not** also in `APP_AUTH_ALLOWED_EMAILS` unless you intend a full admin (admin
+2. Ensure the email is **not** also in `APP_AUTH_ADMIN_EMAILS` unless you intend a full admin (admin
    precedence applies).
 
 3. Restart / redeploy so the configuration is picked up.
 
 4. The user signs in at `/backoffice` with Google. `GET /auth/me` reflects their access — reporting the
-   `backoffice.read_only` capability once #178/#180 expose it (today `/auth/me` returns only
+   granted capabilities (e.g. `backoffice.read`) once #180 exposes them (today `/auth/me` returns only
    `isAuthenticated`, `email`, and `isAuthorized`) — and the UI renders every module in read-only mode,
    hiding write affordances.
 
@@ -170,7 +175,7 @@ _Current exceptions: none._
 - **A read-only user still succeeds on a write via the API.** The route uses a non-mutating verb for a
   mutation (e.g. a write behind `GET`), or sits outside `/api/**`. Fix the verb/placement or add a
   documented exception.
-- **An admin gets `403`.** Their email isn't in `APP_AUTH_ALLOWED_EMAILS` (check casing/whitespace — the
+- **An admin gets `403`.** Their email isn't in `APP_AUTH_ADMIN_EMAILS` (check casing/whitespace — the
   list is normalized) or the app didn't pick up the new env value (restart/redeploy).
 - **A read-only user gets `403` on a legitimate read.** Confirm the read uses `GET`/`HEAD` and the email
   is in `APP_AUTH_READ_ONLY_EMAILS`; if it's a `POST`-based read, it needs a documented exception.
@@ -201,6 +206,6 @@ Sign in with an **unauthorized** Google account (in neither list) and confirm:
 
 > **Backoffice read-only role.** Operators can now grant view-only backoffice access by adding emails to
 > `APP_AUTH_READ_ONLY_EMAILS`. These users can browse all backoffice modules (lists and details) but
-> cannot create, edit, delete, archive, or restore anything. Admins listed in `APP_AUTH_ALLOWED_EMAILS`
+> cannot create, edit, delete, archive, or restore anything. Admins listed in `APP_AUTH_ADMIN_EMAILS`
 > keep full access; an email present in both lists remains a full admin.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "type": "module",
   "packageManager": "pnpm@11.20.0",
   "scripts": {

--- a/render.yaml
+++ b/render.yaml
@@ -9,7 +9,9 @@ services:
     envVars:
       - key: SPRING_PROFILES_ACTIVE
         value: prod
-      - key: APP_AUTH_ALLOWED_EMAILS
+      - key: APP_AUTH_ADMIN_EMAILS
+        sync: false
+      - key: APP_AUTH_READ_ONLY_EMAILS
         sync: false
       - key: APP_AUTH_SUCCESS_REDIRECT_URL
         sync: false


### PR DESCRIPTION
Closes #178 