### PR TITLE
 feat(#181): 🚫 Block all backoffice write endpoints for read-only users

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 
 group = "me.elgregoss"
-version = "0.0.49-SNAPSHOT"
+version = "0.0.50-SNAPSHOT"
 
 java {
     toolchain {

--- a/backend/src/integrationTest/kotlin/me/elgregos/theweddingplan/api/auth/BackofficeReadOnlyPolicyIT.kt
+++ b/backend/src/integrationTest/kotlin/me/elgregos/theweddingplan/api/auth/BackofficeReadOnlyPolicyIT.kt
@@ -132,6 +132,30 @@ class BackofficeReadOnlyPolicyIT : AbstractEndpointIntegrationTest() {
     }
 
     @Test
+    fun `should forbid read-only user from mutating through an unmapped verb`() {
+        val csrf = authenticatedCsrfContext(readOnlyEmail)
+
+        restTestClient.patch().uri("/api/guests/${johnDoe.id}")
+            .header(HttpHeaders.COOKIE, csrf.cookies)
+            .header("X-XSRF-TOKEN", csrf.csrfToken)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isForbidden
+    }
+
+    @Test
+    fun `should forbid read-only user from mutating a module without a matching write route`() {
+        val csrf = authenticatedCsrfContext(readOnlyEmail)
+
+        restTestClient.delete().uri("/api/invitations/${brideFamilyInvitation.id}")
+            .header(HttpHeaders.COOKIE, csrf.cookies)
+            .header("X-XSRF-TOKEN", csrf.csrfToken)
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isForbidden
+    }
+
+    @Test
     fun `should forbid an authenticated but unlisted user from reading`() {
         val csrf = authenticatedCsrfContext(unlistedEmail)
 

--- a/docs/backoffice-read-only-permissions.md
+++ b/docs/backoffice-read-only-permissions.md
@@ -54,6 +54,11 @@ Because the rule keys off the HTTP verb, **any new module that follows REST conv
 automatically** — reads use `GET`, writes use `POST`/`PUT`/`PATCH`/`DELETE`. Blocking happens at the
 **API layer** (server-side), so hiding UI controls is defense-in-depth, not the only guard.
 
+The check runs in the security filter chain **before request routing**, and any verb that is not `GET`/`HEAD`
+is treated as a write (fail-closed). A read-only user therefore gets `403` even on a verb or path a module
+never declared (e.g. `PATCH /api/guests/{id}`, or `DELETE /api/invitations/{id}` where no delete route
+exists) — there is no bypass via direct URL or verb manipulation.
+
 ### Illustrative matrix
 
 Concrete examples of the global rule on the two current modules:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "type": "module",
   "packageManager": "pnpm@11.20.0",
   "scripts": {


### PR DESCRIPTION
Closes #181 