### PR TITLE
 feat(#182): 🧩 Migrate Invitations module to global backoffice read-only rules

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 
 group = "me.elgregoss"
-version = "0.0.50-SNAPSHOT"
+version = "0.0.51-SNAPSHOT"
 
 java {
     toolchain {

--- a/frontend/backoffice/src/App.spec.ts
+++ b/frontend/backoffice/src/App.spec.ts
@@ -166,6 +166,17 @@ describe('App auth states', () => {
     expect(router.currentRoute.value.name).toBe(BACKOFFICE_ROUTE_NAMES.accessDenied);
   });
 
+  it('redirects read-only users away from invitation write routes to access denied', async () => {
+    mockAuthStatus(readOnlyAuthStatus);
+
+    const { router } = await mountApp({ route: '/invitations' });
+
+    await router.push({ name: BACKOFFICE_ROUTE_NAMES.invitationAdd });
+    await flushPromises();
+
+    expect(router.currentRoute.value.name).toBe(BACKOFFICE_ROUTE_NAMES.accessDenied);
+  });
+
   it('does not refetch auth status in App when only the query string changes', async () => {
     mockAuthStatus();
 

--- a/frontend/backoffice/src/views/InvitationDetailsView.spec.ts
+++ b/frontend/backoffice/src/views/InvitationDetailsView.spec.ts
@@ -1,9 +1,10 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { createMemoryHistory, createRouter } from 'vue-router';
 import { defineComponent } from 'vue';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import InvitationDetailsView from './InvitationDetailsView.vue';
 import { BACKOFFICE_ROUTE_NAMES } from '../router/routeNames';
+import { applyCapabilities, resetCapabilities } from '../composables/useCapabilities';
 
 const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
   dateStyle: 'medium',
@@ -19,6 +20,11 @@ vi.mock('../services/invitationApi', () => ({
 describe('InvitationDetailsView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    applyCapabilities({ canWrite: true });
+  });
+
+  afterEach(() => {
+    resetCapabilities();
   });
 
   const mountView = async ({
@@ -172,5 +178,42 @@ describe('InvitationDetailsView', () => {
 
     expect(wrapper.get('[data-test="invitation-details-error"]').text()).toBe('Invitation not found.');
     expect(wrapper.find('[data-test="invitation-details-card"]').exists()).toBe(false);
+  });
+
+  it('shows the edit link for users with write access', async () => {
+    getInvitationByIdMock.mockResolvedValue({
+      id: 'inv-1',
+      accessToken: 'token-invitation-1234567890',
+      version: 1,
+      creationDate: '2026-07-03T10:00:00Z',
+      updateDate: '2026-07-04T10:00:00Z',
+      label: 'Family table',
+      description: 'Main family table',
+      guests: [],
+      guestCount: 0
+    });
+
+    const { wrapper } = await mountView();
+
+    expect(wrapper.get('[data-test="edit-invitation-link"]').attributes('href')).toBe('/invitations/inv-1/edit');
+  });
+
+  it('hides the edit link in read-only mode', async () => {
+    resetCapabilities();
+    getInvitationByIdMock.mockResolvedValue({
+      id: 'inv-1',
+      accessToken: 'token-invitation-1234567890',
+      version: 1,
+      creationDate: '2026-07-03T10:00:00Z',
+      updateDate: '2026-07-04T10:00:00Z',
+      label: 'Family table',
+      description: 'Main family table',
+      guests: [],
+      guestCount: 0
+    });
+
+    const { wrapper } = await mountView();
+
+    expect(wrapper.find('[data-test="edit-invitation-link"]').exists()).toBe(false);
   });
 });

--- a/frontend/e2e/fixtures/authSetup.ts
+++ b/frontend/e2e/fixtures/authSetup.ts
@@ -15,3 +15,18 @@ export const allowAdminSession = async (page: Page) => {
   });
 };
 
+export const allowReadOnlySession = async (page: Page) => {
+  await page.route('**/auth/me', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        authenticated: true,
+        authorized: true,
+        canWrite: false,
+        email: 'viewer@example.com'
+      })
+    });
+  });
+};
+

--- a/frontend/e2e/invitation-read-only.spec.ts
+++ b/frontend/e2e/invitation-read-only.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+import { allowReadOnlySession } from './fixtures/authSetup';
+import { fulfillJson } from './fixtures/httpHelpers';
+import { NAVIGATION_TIMEOUT_MS, UI_TIMEOUT_MS } from './fixtures/timeouts';
+
+test.describe('Invitations read-only access', () => {
+  test('read-only user browses invitations without write controls', async ({ page }) => {
+    await allowReadOnlySession(page);
+
+    await page.route('**/api/invitations*', async (route) => {
+      await fulfillJson(route, {
+        items: [
+          {
+            id: 'inv-1',
+            accessToken: 'token-inv-1',
+            version: 1,
+            creationDate: '2026-07-03T10:00:00Z',
+            updateDate: '2026-07-03T10:00:00Z',
+            label: 'Family table',
+            description: 'Main family table',
+            guests: [
+              {
+                id: 'guest-1',
+                firstName: 'Alice',
+                lastName: 'Martin',
+                email: 'alice@example.com'
+              }
+            ],
+            guestCount: 1
+          }
+        ],
+        page: 0,
+        size: 20,
+        totalItems: 1,
+        totalPages: 1
+      });
+    });
+
+    const invitationsLoaded = page.waitForResponse((response) =>
+      response.url().includes('/api/invitations') && response.request().method() === 'GET'
+    );
+
+    await page.goto('/invitations');
+    await invitationsLoaded;
+
+    await expect(page.locator('[data-test="invitation-card"]')).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await expect(page.locator('[data-test="create-invitation-cta"]')).toHaveCount(0);
+    await expect(page.locator('a[aria-label="View invitation"]')).toBeVisible();
+    await expect(page.locator('a[aria-label="Edit invitation"]')).toHaveCount(0);
+  });
+
+  test('read-only user is redirected from invitation write route to access denied', async ({ page }) => {
+    await allowReadOnlySession(page);
+
+    await page.goto('/invitations/new');
+
+    await expect(page).toHaveURL(/\/access-denied$/, { timeout: NAVIGATION_TIMEOUT_MS });
+    await expect(page.getByText('Your account is not authorized to access this backoffice.')).toBeVisible({ timeout: UI_TIMEOUT_MS });
+  });
+});
+
+
+
+
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "type": "module",
   "packageManager": "pnpm@11.20.0",
   "scripts": {


### PR DESCRIPTION
Closes #182 