### PR TITLE
 feat(#183): 🧩 Migrate remaining backoffice modules to global read-only rules

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 
 group = "me.elgregoss"
-version = "0.0.51-SNAPSHOT"
+version = "0.0.52-SNAPSHOT"
 
 java {
     toolchain {

--- a/frontend/backoffice/src/App.spec.ts
+++ b/frontend/backoffice/src/App.spec.ts
@@ -155,6 +155,18 @@ describe('App auth states', () => {
     expect(wrapper.findComponent({ name: 'GuestListView' }).exists()).toBe(true);
   });
 
+  it('surfaces only read routes in navigation for read-only users', async () => {
+    mockAuthStatus(readOnlyAuthStatus);
+
+    const { wrapper } = await mountApp({ route: '/guests' });
+
+    const navHrefs = wrapper
+      .findAll('nav[aria-label="Backoffice navigation"] a')
+      .map((link) => link.attributes('href'));
+
+    expect(navHrefs).toEqual(['/invitations', '/guests']);
+  });
+
   it('redirects read-only users away from write routes to access denied', async () => {
     mockAuthStatus(readOnlyAuthStatus);
 

--- a/frontend/backoffice/src/components/BackofficeSidebar.spec.ts
+++ b/frontend/backoffice/src/components/BackofficeSidebar.spec.ts
@@ -39,6 +39,7 @@ describe('BackofficeSidebar', () => {
     expect(links[1].attributes('href')).toBe('/guests');
   });
 
+
   it('marks invitations link as active on invitations routes', async () => {
     const wrapper = await createSidebarWrapper('/invitations');
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "type": "module",
   "packageManager": "pnpm@11.20.0",
   "scripts": {


### PR DESCRIPTION
Closes #183 